### PR TITLE
Flake8 fixes

### DIFF
--- a/{{cookiecutter.package_name}}/Makefile
+++ b/{{cookiecutter.package_name}}/Makefile
@@ -94,6 +94,7 @@ format:
 .PHONY: check-format
 check-format:
 	@hatch run style:run-black-check
+	@hatch run style:run-flake8
 
 
 # help: sort-imports                   - apply import sort ordering

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -135,7 +135,7 @@ extra-dependencies = [
 ]
 
 [tool.hatch.envs.style.scripts]
-run-flake8 = "flake8 --ignore=E203,W503 src tests"
+run-flake8 = "flake8 src tests"
 run-isort = "isort src tests --profile black"
 run-isort-check = "run-isort --check-only"
 run-black = "black examples src tests"


### PR DESCRIPTION
We run flake8 as part of GitHub Actions, so it make sense to also run it from the appropriate Makefile target.

Additionally, this removes an `--ignore=` directive, since we should not presume to know what the user may want. This is especially true for E203, where there should be no concern regarding incompatibility with other formatting tools such as black.

* [Whitespace before ':' (E203)](https://www.flake8rules.com/rules/E203.html)
* [Line break occurred before a binary operator (W503)](https://www.flake8rules.com/rules/W503.html)