### PR TITLE
Tweak environment-specific Python versions

### DIFF
--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -131,6 +131,7 @@ extra-dependencies = [
 check = "pylint src tests examples"
 
 [tool.hatch.envs.style]
+python = "3.14"
 detached = true
 extra-dependencies = [
   "black",

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -70,6 +70,9 @@ only-include = [
 [tool.hatch.build.targets.wheel]
 packages = ["src/{{cookiecutter.package_name}}"]
 
+[tool.hatch.envs.default]
+python = "3.11"
+
 [tool.hatch.envs.hatch-test]
 extra-dependencies = [
   "pytest",


### PR DESCRIPTION
Have Hatch default to running under the oldest version of Python that is supported by a new project by default, which is Python 3.11.

However, have style-related utilities execute in an environment using the latest supported version of Python, which is currently 3.14. Doing so avoids this type of warning:
```
$ hatch run style:run-black
Warning: Python 3.12 cannot parse code formatted for Python 3.14. To fix this: run Black with Python 3.14, set --target-version to py312, or use --fast to skip the safety check. Black's safety check verifies equivalence by parsing the AST, which fails when the running Python is older than the target version.
All done! ✨ 🍰 ✨
6 files left unchanged.
$
```